### PR TITLE
fix: books stream id underscore

### DIFF
--- a/tap_lotr/streams.py
+++ b/tap_lotr/streams.py
@@ -12,7 +12,7 @@ class BooksStream(lotrStream):
     """Define custom stream."""
     name = "books"
     path = "/book"
-    primary_keys = ["id"]
+    primary_keys = ["_id"]
     replication_key = None
 
     schema = th.PropertiesList(


### PR DESCRIPTION
Thanks for the tap! using this to test against a snowflake loader and running into primary key issues because of this so in this I've just updated the primary keys for the books stream. Tested the change with snowflake and all is well.